### PR TITLE
Update git-init.sh - check staged file instead of working file

### DIFF
--- a/git-init.sh
+++ b/git-init.sh
@@ -7,7 +7,7 @@
 if [ -d .git/ ]; then
 rm .git/hooks/pre-commit
 cat <<EOT >> .git/hooks/pre-commit
-if ( git show :vars/vault.yml | grep -q "\$ANSIBLE_VAULT;" ); then
+if ( git show :vars/vault.yaml | grep -q "\$ANSIBLE_VAULT;" ); then
 echo "[38;5;108mVault Encrypted. Safe to commit.[0m"
 else
 echo "[38;5;208mVault not encrypted! Run 'make encrypt' and try again.[0m"

--- a/git-init.sh
+++ b/git-init.sh
@@ -7,7 +7,7 @@
 if [ -d .git/ ]; then
 rm .git/hooks/pre-commit
 cat <<EOT >> .git/hooks/pre-commit
-if ( cat vars/vault.yaml | grep -q "\$ANSIBLE_VAULT;" ); then
+if ( git show :vars/vault.yml | grep -q "\$ANSIBLE_VAULT;" ); then
 echo "[38;5;108mVault Encrypted. Safe to commit.[0m"
 else
 echo "[38;5;208mVault not encrypted! Run 'make encrypt' and try again.[0m"


### PR DESCRIPTION
Previously, test would only check the working directory for the encrypted vault.
This allowed an edge case where the following could occur:
1) Unencrypted vault is added to staging.
2) Vault is encrypted, but is not added to staging.
3) Commit succeeds, storing the unencrypted vault.

The new test improves the old by checking against the staged file, instead of the working file.