### PR TITLE
[codex] Align media services with live routing

### DIFF
--- a/files/adguardhome/AdGuardHome.yaml
+++ b/files/adguardhome/AdGuardHome.yaml
@@ -165,7 +165,7 @@ filtering:
       answer: 10.42.1.137
       enabled: true
     - domain: '*.m.wd.ktz.me'
-      answer: 10.42.1.137
+      answer: 10.42.1.111
       enabled: true
     - domain: ha.wd.ktz.me
       answer: 10.42.1.99
@@ -173,14 +173,20 @@ filtering:
     - domain: '*.wd.ktz.me'
       answer: 10.42.0.53
       enabled: true
+    - domain: jf.demo.ktz.me
+      answer: 10.42.0.53
+      enabled: true
+    - domain: '*.demo.ktz.me'
+      answer: 192.168.1.10
+      enabled: true
     - domain: hass.ktz.me
       answer: 10.42.1.99
       enabled: true
     - domain: nc.ktz.cloud
-      answer: 10.42.1.137
+      answer: 10.42.1.111
       enabled: true
     - domain: audiobooks.wd.ktz.me
-      answer: 10.42.1.137
+      answer: 10.42.1.111
       enabled: true
     - domain: '*.norbert.ktz.me'
       answer: 192.168.17.100

--- a/group_vars/core.yaml
+++ b/group_vars/core.yaml
@@ -84,7 +84,7 @@ caddy_endpoints:
         tls_insecure: true
       - friendly_name: fwd
         fqdn: fwd.wd.ktz.me
-        upstream: https://192.168.1.13:8006
+        upstream: https://10.42.1.13:8006
         tls_insecure: true
       ## Apps and Services
       - friendly_name: jellyfin
@@ -99,6 +99,14 @@ caddy_endpoints:
       - friendly_name: immichframe-family
         fqdn: immichframe-family.wd.ktz.me
         upstream: http://10.42.0.111:8081
+  ## DEMO
+  - friendly_name: wildcard for *.demo.ktz.me
+    fqdn: '*.demo.ktz.me'
+    tls_provider: cloudflare
+    wildcard_endpoints:
+      - friendly_name: jellyfin demo
+        fqdn: jf.demo.ktz.me
+        upstream: http://192.168.1.10:8096
   ## HOME
   - friendly_name: wildcard for *.home.ktz.me
     fqdn: '*.home.ktz.me'

--- a/services/appnv/02-mediaservers/compose.yaml
+++ b/services/appnv/02-mediaservers/compose.yaml
@@ -27,8 +27,8 @@ services:
     volumes:
       - "{{ appdata_path }}/mediaservers/storyteller/data:/data:rw"
       - "{{ appdata_path }}/mediaservers/storyteller/config:/config:ro"
-      - "{{ storage_path }}/media/books:/books:ro"
-      - "{{ storage_path }}/media/audiobooks:/audiobooks:ro"
+      - "{{ storage_path }}/media/books:/books"
+      - "{{ storage_path }}/media/audiobooks:/audiobooks"
     labels:
       - traefik.enable=true
       - "traefik.http.routers.storyteller.rule=Host(`storyteller.{{ m_wd_domain_me }}`)"

--- a/services/appnv/04-monitoring/compose.yaml
+++ b/services/appnv/04-monitoring/compose.yaml
@@ -52,18 +52,3 @@ services:
       - HISTORY=2h
       - "BASE_URL=https://ping.{{ m_wd_domain_me }}"
     restart: unless-stopped
-  tautulli:
-    image: lscr.io/linuxserver/tautulli:latest
-    container_name: tautulli
-    volumes:
-      - "{{ appdata_path }}/mediaservers/tautulli:/config"
-      - "{{ appdata_path }}/mediaservers/plex/config/Library/Application Support/Plex Media Server/Logs:/logs:ro"
-    labels:
-      - traefik.enable=true
-      - "traefik.http.routers.tautulli.rule=Host(`tautulli.m.wd.ktz.me`)"
-      - traefik.http.services.tautulli.loadbalancer.server.port=8181
-    environment:
-      - "PUID={{ docker_compose_generator_uid }}"
-      - "PGID={{ docker_compose_generator_gid }}"
-      - "TZ={{ host_timezone }}"
-    restart: unless-stopped

--- a/services/meeseeks/compose.yaml
+++ b/services/meeseeks/compose.yaml
@@ -1,26 +1,5 @@
 services:
 ## media servers
-  plex:
-    image: plexinc/pms-docker
-    container_name: plex
-    network_mode: host
-    devices:
-      - /dev/dri:/dev/dri
-    volumes:
-      - "{{ appdata_path }}/mediaservers/plex/config:/config"
-      - "{{ storage_path }}:{{ storage_path }}:ro"
-      - "/mnt/downloads/complete:/downloads"
-    labels:
-      - traefik.enable=false
-    environment:
-      - "PUID={{ docker_compose_generator_uid }}"
-      - "PGID={{ docker_compose_generator_gid }}"
-      - "TZ={{ host_timezone }}"
-      - "TRANSCODE_PATH=/transcode"
-      - "ADVERTISE_IP=http://10.42.1.10:32400"
-    tmpfs:
-      - /transcode:noexec,nosuid,size=8g
-    restart: unless-stopped
   jellyfin:
     image: jellyfin/jellyfin
     container_name: jellyfin


### PR DESCRIPTION
## Summary

This PR aligns the media service routing/configuration with the live infrastructure state.

Changes include:

- Update AdGuard Home rewrites for the current media/app routing targets.
- Add the `*.demo.ktz.me` Caddy wildcard endpoint for the Jellyfin demo route.
- Make Storyteller book and audiobook mounts writable instead of read-only.
- Remove retired Tautulli and Plex compose entries that are no longer running.

## Why

These changes were split out from the local LLM/Hermes branch because they are actual infra/media routing fixes and should be reviewed independently from the Framework LLM work.

## Impact

- Keeps DNS/Caddy routing in Git aligned with the live core/appnv state.
- Prevents retired Plex/Tautulli services from being redeployed by compose generation.
- Allows Storyteller to write to its book/audiobook mounts where needed.

## Validation

- `git diff --check main..HEAD`
- `ansible-playbook --syntax-check run.yaml`
- `ansible-inventory --graph`
- GitHub compare confirms this branch is 1 commit ahead of `main` and touches only the expected media/routing files.

Known warning: Ansible still reports the existing `ktz-cloud` group/host name warning; this PR does not introduce it.